### PR TITLE
feat: LoginScreen, 임시 회원가입 및 자동로그인 기능 구현

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -602,33 +602,33 @@ PODS:
   - BoringSSL-GRPC/Implementation (0.0.24):
     - BoringSSL-GRPC/Interface (= 0.0.24)
   - BoringSSL-GRPC/Interface (0.0.24)
-  - cloud_firestore (4.1.0):
-    - Firebase/Firestore (= 10.2.0)
+  - cloud_firestore (4.0.5):
+    - Firebase/Firestore (= 10.1.0)
     - firebase_core
     - Flutter
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - Firebase/CoreOnly (10.2.0):
-    - FirebaseCore (= 10.2.0)
-  - Firebase/Firestore (10.2.0):
+  - Firebase/CoreOnly (10.1.0):
+    - FirebaseCore (= 10.1.0)
+  - Firebase/Firestore (10.1.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 10.2.0)
-  - Firebase/Messaging (10.2.0):
+    - FirebaseFirestore (~> 10.1.0)
+  - Firebase/Messaging (10.1.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.2.0)
-  - firebase_core (2.3.0):
-    - Firebase/CoreOnly (= 10.2.0)
+    - FirebaseMessaging (~> 10.1.0)
+  - firebase_core (2.2.0):
+    - Firebase/CoreOnly (= 10.1.0)
     - Flutter
   - firebase_messaging (14.1.0):
-    - Firebase/Messaging (= 10.2.0)
+    - Firebase/Messaging (= 10.1.0)
     - firebase_core
     - Flutter
-  - FirebaseCore (10.2.0):
+  - FirebaseCore (10.1.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.2.0):
+  - FirebaseCoreInternal (10.3.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseFirestore (10.2.0):
+  - FirebaseFirestore (10.1.0):
     - abseil/algorithm (~> 1.20211102.0)
     - abseil/base (~> 1.20211102.0)
     - abseil/container/flat_hash_map (~> 1.20211102.0)
@@ -641,12 +641,12 @@ PODS:
     - "gRPC-C++ (~> 1.44.0)"
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseInstallations (10.2.0):
+  - FirebaseInstallations (10.3.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.2.0):
+  - FirebaseMessaging (10.1.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleDataTransport (~> 9.2)
@@ -813,15 +813,15 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   abseil: ebe5b5529fb05d93a8bdb7951607be08b7fa71bc
   BoringSSL-GRPC: 3175b25143e648463a56daeaaa499c6cb86dad33
-  cloud_firestore: 14451f06cca99dbd56b069624621063150fef3e5
-  Firebase: a3ea7eba4382afd83808376edb99acdaff078dcf
-  firebase_core: db1432de826785171029b7c1a26e5b22ce1dd477
-  firebase_messaging: 77f3d888b3551738b41530cdec8b7b46721b3218
-  FirebaseCore: 813838072b797b64f529f3c2ee35e696e5641dd1
-  FirebaseCoreInternal: 091bde13e47bb1c5e9fe397634f3593dc390430f
-  FirebaseFirestore: bda7a1ca8c19319a2acd2761cd4b962022c1d5ea
-  FirebaseInstallations: 004915af170935e3a583faefd5f8bc851afc220f
-  FirebaseMessaging: cc9f40f5b7494680f3844d08e517e92aa4e8d9f7
+  cloud_firestore: 345ab5f423db6ae492abb648372156bdccb9df42
+  Firebase: 444b35a9c568a516666213c2f6cccd10cb12559f
+  firebase_core: d2242c6f318db1d0dcecfbfa491e943337b0d755
+  firebase_messaging: 59f435c4cd0d5448e7268a7f70bce9b1287c1742
+  FirebaseCore: 55e7ae35991ccca4db03ff8d8df6ed5f17a3e4c7
+  FirebaseCoreInternal: 29b76f784d607df8b2a1259d73c3f04f1210137b
+  FirebaseFirestore: d482e5e0f95dba8ef5d499a7efa87ba2f56ef0c0
+  FirebaseInstallations: e2f26126089dcf41e215f7b8925af8d953c7d602
+  FirebaseMessaging: 4487bbff9b9b927ba1dd3ea40d1ceb58e4ee3cb5
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be

--- a/lib/functions/fcmController/fcmController.dart
+++ b/lib/functions/fcmController/fcmController.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:http/http.dart' as http;
-import 'package:telepathy_flutter/functions/firebase_messaging_api_key.dart';
+import 'firebase_messaging_api_key.dart';
 
 class FCMController {
   final String _serverKey = serverKey;

--- a/lib/global.dart
+++ b/lib/global.dart
@@ -1,0 +1,1 @@
+String MY_PHONE_NUM = "";

--- a/lib/screens/Home/HomeProvider.dart
+++ b/lib/screens/Home/HomeProvider.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:telepathy_flutter/global.dart' as globals;
 
-const MY_PHONE_NUM = "01053618962";
+// const MY_PHONE_NUM = "01053618962";
 
 final firestore = FirebaseFirestore.instance;
 
@@ -40,7 +41,7 @@ Future<List> getMyReceivedTelepathyList() async {
 
   QuerySnapshot querySnapshot = await firestore
       .collection('messageData')
-      .doc(MY_PHONE_NUM)
+      .doc(globals.MY_PHONE_NUM)
       .collection("receivedMessage")
       .get();
 
@@ -55,7 +56,7 @@ Future<List> getMyReceivedTelepathyList() async {
 //   final List mySentMessageList = [];
 //   QuerySnapshot result = await firestore
 //       .collection('messageData')
-//       .doc(MY_PHONE_NUM)
+//       .doc(globals.MY_PHONE_NUM)
 //       .collection("sentMessage")
 //       .get();
 //   result.docs.forEach((doc) {
@@ -71,13 +72,13 @@ Future<List> getMySentTelepathyList() async {
 
   QuerySnapshot querySnapshot = await firestore
       .collection('messageData')
-      .doc(MY_PHONE_NUM)
+      .doc(globals.MY_PHONE_NUM)
       .collection("sentMessage")
       .get();
 
   // Query query = await firestore
   //     .collection('messageData')
-  //     .doc(MY_PHONE_NUM)
+  //     .doc(globals.MY_PHONE_NUM)
   //     .collection("sentMessage");
   // QuerySnapshot result =
   //     await query.where("targetPhoneNum", isEqualTo: '01099999999').get();

--- a/lib/screens/Home/WritingMessageScreen.dart
+++ b/lib/screens/Home/WritingMessageScreen.dart
@@ -3,8 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:telepathy_flutter/global.dart' as globals;
 
-const MY_PHONE_NUM = "01053618962";
+// const MY_PHONE_NUM = "01053618962";
 
 class WritingMessageScreen extends StatefulWidget {
   const WritingMessageScreen({super.key});
@@ -218,10 +219,15 @@ class _WritingMessageScreenState extends State<WritingMessageScreen> {
         return;
       }
 
+      if (phoneNumberTextController.text == globals.MY_PHONE_NUM) {
+        showCheckingPhoneNumDialog(context: context, text: "본인에게 보낼 수 없어요!");
+        return;
+      }
+
       try {
         await firestore
             .collection("messageData")
-            .doc(MY_PHONE_NUM)
+            .doc(globals.MY_PHONE_NUM)
             .collection("sentMessage")
             .doc(phoneNumberTextController.text)
             .set({

--- a/lib/screens/Intro/Intro.dart
+++ b/lib/screens/Intro/Intro.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import 'package:go_router/go_router.dart';
 import 'package:telepathy_flutter/kakao_login.dart';
+import 'package:telepathy_flutter/screens/Home/PlanetScreen.dart';
 import 'package:telepathy_flutter/screens/LoginScreen.dart';
 
 class IntroScreen extends StatefulWidget {
@@ -63,7 +64,10 @@ class _IntroScreenState extends State<IntroScreen> {
                 onPressed: () {
                   setState(() {
                     if (screenNumber == 3) {
-                      KakaoLogin().login();
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) => const PlanetScreen()));
                     } else {
                       screenNumber++;
                     }

--- a/lib/screens/LoginScreen.dart
+++ b/lib/screens/LoginScreen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:telepathy_flutter/kakao_login.dart';
 import 'package:telepathy_flutter/main_view_model.dart';
 import 'package:telepathy_flutter/screens/Home/PlanetScreen.dart';
@@ -16,12 +18,74 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
+  final _storage = const FlutterSecureStorage();
   final viewModel = MainViewModel(KakaoLogin());
   final firestore = FirebaseFirestore.instance;
 
+  final nameTextController = TextEditingController();
+  final phoneNumberTextController = TextEditingController();
+
   getData() async {
     var result = await firestore.collection('example').doc("exampleDocs").get();
+    print(result);
     return result;
+  }
+
+  //같은 doc으로 보내면, 초기화가 됨
+  bool isValidInput() {
+    // TODO: 벨리데이션 함수로 분리 필요
+    if (phoneNumberTextController.text.length != 11 ||
+        phoneNumberTextController.text.substring(0, 3) != "010") {
+      print(phoneNumberTextController.text);
+      print("전화번호를 확인해주세요");
+      return false;
+    }
+    // if (phoneNumberTextController.text)
+    if (nameTextController.text.length == 0) {
+      print(nameTextController.text);
+      print("이름이 비어있습니다");
+      return false;
+    }
+    print("이름, 번호 유효성 확인!");
+    return true;
+  }
+
+  Future<void> SignIn() async {
+    /// 파베로부터 전화번호를 가져와 중복이 있는 확인
+    /// 중복이라면 에러 반환
+    /// 아니라면 파베 저장
+    /// secure-store에 저장(자동 로그인) -> TODO: 로그인 스크린 넘어오기 전에 메인에서 자동 로그인 하도록 구현하기
+    try {
+      DocumentSnapshot user = await firestore
+          .collection("user")
+          .doc(phoneNumberTextController.text)
+          .get();
+      if (user.exists) {
+        print("이미 존재하는 유저입니다");
+        print(user.data());
+      } else {
+        print("유저 정보를 저장합니다");
+        await firestore
+            .collection("user")
+            .doc(phoneNumberTextController.text)
+            .set({
+          "name": nameTextController.text,
+          "phoneNum": phoneNumberTextController.text
+        });
+      }
+
+      Fluttertoast.showToast(
+          msg: "교신 시작합니다",
+          toastLength: Toast.LENGTH_LONG,
+          gravity: ToastGravity.BOTTOM,
+          timeInSecForIosWeb: 1,
+          backgroundColor: Colors.black,
+          textColor: const Color(0xff72D4A5),
+          fontSize: 18.0);
+      Navigator.pop(context);
+    } catch (err) {
+      print("validateLogin err: $err");
+    }
   }
 
   @override
@@ -29,135 +93,230 @@ class _LoginScreenState extends State<LoginScreen> {
     return Scaffold(
         backgroundColor: Color(0xff1A1A22),
         body: Container(
-          width: MediaQuery.of(context).size.width,
-          child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Column(
-                  children: [
-                    Text("TELEPATHY",
+            width: MediaQuery.of(context).size.width,
+            child: Column(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                // 새 로비화면 start
+                children: [
+                  Column(
+                    children: [
+                      const Text(
+                        "당신의 누구인가요?",
                         style: TextStyle(
-                            fontSize: 50,
+                          color: Color(0xff72D4A5),
+                          fontFamily: "neodgm",
+                          fontSize: 20,
+                        ),
+                      ),
+                      SizedBox(
+                        width: MediaQuery.of(context).size.width - 100,
+                        height: 80,
+
+                        // ignore: prefer_const_constructors
+                        child: TextField(
+                          style: const TextStyle(
                             fontFamily: "neodgm",
-                            color: Color(0xff72D4A5))),
-                    Text("Login Screen",
+                            fontSize: 20,
+                            color: Color(0xff72D4A5),
+                          ),
+                          decoration: const InputDecoration(
+                            border: InputBorder.none,
+                            hintText: '이름',
+                            hintStyle: TextStyle(
+                              color: Color(0xff479871),
+                            ),
+                          ),
+                          controller: nameTextController,
+                        ),
+                      ),
+                      const Text(
+                        "당신의 연락처를 알려주세요",
                         style: TextStyle(
-                            fontSize: 25,
+                          color: Color(0xff72D4A5),
+                          fontFamily: "neodgm",
+                          fontSize: 20,
+                        ),
+                      ),
+                      SizedBox(
+                        width: MediaQuery.of(context).size.width - 100,
+                        height: 80,
+                        // ignore: prefer_const_constructors
+                        child: TextField(
+                          style: const TextStyle(
                             fontFamily: "neodgm",
-                            color: Color(0xff72D4A5))),
-                  ],
-                ),
-                Column(
-                  children: [
-                    ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.black,
-                          foregroundColor: Colors.white),
-                      onPressed: () {
-                        Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => const PlanetScreen()));
-                      },
-                      child: Text(
-                        "회원가입하기",
+                            fontSize: 20,
+                            color: Color(0xff72D4A5),
+                          ),
+                          decoration: const InputDecoration(
+                            border: InputBorder.none,
+                            hintText: '전화번호 11자리',
+                            hintStyle: TextStyle(
+                              color: Color(0xff479871),
+                            ),
+                          ),
+                          controller: phoneNumberTextController,
+                        ),
                       ),
-                    ),
-                    ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.black,
-                          foregroundColor: Colors.white),
-                      onPressed: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => const IntroScreen()),
-                        );
-                      },
-                      child: Text(
-                        "인트로보기",
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 12.0),
+                        child: ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                              textStyle: const TextStyle(
+                                color: Color(0xff72D4A5),
+                                fontFamily: "neodgm",
+                                fontSize: 20,
+                              ),
+                              backgroundColor: const Color(0xff72D4A5),
+                              minimumSize: const Size(30, 45)),
+                          onPressed: () async {
+                            if (isValidInput()) {
+                              await SignIn();
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (context) => const IntroScreen()),
+                              );
+                            }
+                            ;
+                          },
+                          child: const Text(
+                            "텔레파시 시작하기",
+                            style: TextStyle(color: Colors.black),
+                          ),
+                        ),
                       ),
-                    ),
-                    ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.amber,
-                          foregroundColor: Colors.black),
-                      onPressed: () async {
-                        await viewModel.login();
-                        setState(() {});
-                      },
-                      child: Text(
-                        "카카오톡 로그인하기",
-                      ),
-                    ),
-                  ],
-                ),
-                Column(
-                  children: [
-                    Container(
-                      height: 1,
-                      width: MediaQuery.of(context).size.width,
-                      color: Colors.white,
-                    ),
-                    Text(
-                      "ETC",
-                      style: TextStyle(color: Colors.white, fontSize: 20),
-                    ),
-                    ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.amber,
-                          foregroundColor: Colors.blue),
-                      onPressed: () async {
-                        await viewModel.logout();
-                        setState(() {});
-                      },
-                      child: Text(
-                        "카카오톡 로그아웃하기",
-                      ),
-                    ),
-                    ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.blue,
-                          foregroundColor: Colors.white),
-                      onPressed: () {
-                        fcmController.sendPushNotification(
-                            userToken:
-                                "cfZ8XEdQq0AfkOSRjb7qRm:APA91bGCd0M7wmY-4W3YbAtt_iLizXy_qmmVuQy3abQ7Wmz96eiyydgFCrDxGssawOJpKnhAZlnqJjFRWou5BIuEY7Mwj_D-epHMQLdjIvC1IOFJ--4N4gb4G_7e5F9SGuODDK-BbUJG",
-                            title: "테스트 메세지",
-                            body: "임시 메세지 입니다🚀");
-                      },
-                      child: Text(
-                        "push notification 보내기",
-                      ),
-                    ),
-                    ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.redAccent,
-                          foregroundColor: Colors.white),
-                      onPressed: () async {
-                        final result = await getData();
-                        print(result.data());
-                      },
-                      child: Text(
-                        "Firestore 정보 가져오기 ",
-                      ),
-                    )
-                  ],
-                )
+                    ],
+                  ),
+                ]
+                // 새 로비화면 end
+                // 기존 로비화면
+                // children: [
+                //   Column(
+                //     children: [
+                //       Text("TELEPATHY",
+                //           style: TextStyle(
+                //               fontSize: 50,
+                //               fontFamily: "neodgm",
+                //               color: Color(0xff72D4A5))),
+                //       Text("Login Screen",
+                //           style: TextStyle(
+                //               fontSize: 25,
+                //               fontFamily: "neodgm",
+                //               color: Color(0xff72D4A5))),
+                //     ],
+                //   ),
+                //   Column(
+                //     children: [
+                //       ElevatedButton(
+                //         style: ElevatedButton.styleFrom(
+                //             backgroundColor: Colors.black,
+                //             foregroundColor: Colors.white),
+                //         onPressed: () {
+                //           Navigator.push(
+                //               context,
+                //               MaterialPageRoute(
+                //                   builder: (context) => const PlanetScreen()));
+                //         },
+                //         child: Text(
+                //           "회원가입하기",
+                //         ),
+                //       ),
+                //       ElevatedButton(
+                //         style: ElevatedButton.styleFrom(
+                //             backgroundColor: Colors.black,
+                //             foregroundColor: Colors.white),
+                //         onPressed: () {
+                //           Navigator.push(
+                //             context,
+                //             MaterialPageRoute(
+                //                 builder: (context) => const IntroScreen()),
+                //           );
+                //         },
+                //         child: Text(
+                //           "인트로보기",
+                //         ),
+                //       ),
+                //       ElevatedButton(
+                //         style: ElevatedButton.styleFrom(
+                //             backgroundColor: Colors.amber,
+                //             foregroundColor: Colors.black),
+                //         onPressed: () async {
+                //           await viewModel.login();
+                //           setState(() {});
+                //         },
+                //         child: Text(
+                //           "카카오톡 로그인하기",
+                //         ),
+                //       ),
+                //     ],
+                //   ),
+                //   Column(
+                //     children: [
+                //       Container(
+                //         height: 1,
+                //         width: MediaQuery.of(context).size.width,
+                //         color: Colors.white,
+                //       ),
+                //       Text(
+                //         "ETC",
+                //         style: TextStyle(color: Colors.white, fontSize: 20),
+                //       ),
+                //       ElevatedButton(
+                //         style: ElevatedButton.styleFrom(
+                //             backgroundColor: Colors.amber,
+                //             foregroundColor: Colors.blue),
+                //         onPressed: () async {
+                //           await viewModel.logout();
+                //           setState(() {});
+                //         },
+                //         child: Text(
+                //           "카카오톡 로그아웃하기",
+                //         ),
+                //       ),
+                //       ElevatedButton(
+                //         style: ElevatedButton.styleFrom(
+                //             backgroundColor: Colors.blue,
+                //             foregroundColor: Colors.white),
+                //         onPressed: () {
+                //           fcmController.sendPushNotification(
+                //               userToken:
+                //                   "cfZ8XEdQq0AfkOSRjb7qRm:APA91bGCd0M7wmY-4W3YbAtt_iLizXy_qmmVuQy3abQ7Wmz96eiyydgFCrDxGssawOJpKnhAZlnqJjFRWou5BIuEY7Mwj_D-epHMQLdjIvC1IOFJ--4N4gb4G_7e5F9SGuODDK-BbUJG",
+                //               title: "테스트 메세지",
+                //               body: "임시 메세지 입니다🚀");
+                //         },
+                //         child: Text(
+                //           "push notification 보내기",
+                //         ),
+                //       ),
+                //       ElevatedButton(
+                //         style: ElevatedButton.styleFrom(
+                //             backgroundColor: Colors.redAccent,
+                //             foregroundColor: Colors.white),
+                //         onPressed: () async {
+                //           final result = await getData();
+                //           print(result.data());
+                //         },
+                //         child: Text(
+                //           "Firestore 정보 가져오기 ",
+                //         ),
+                //       )
+                //     ],
+                //   )
 
-                // Image.network(
-                //     viewModel.user?.kakaoAccount?.profile?.profileImageUrl ??
-                //         ""),
+                //   // Image.network(
+                //   //     viewModel.user?.kakaoAccount?.profile?.profileImageUrl ??
+                //   //         ""),
 
-                //
-                // TextField(
-                //   obscureText: false,
-                //   decoration: InputDecoration(
-                //       border: OutlineInputBorder(), labelText: 'Email'),
-                // ),
-              ]),
-        ));
+                //   //
+                //   // TextField(
+                //   //   obscureText: false,
+                //   //   decoration: InputDecoration(
+                //   //       border: OutlineInputBorder(), labelText: 'Email'),
+                //   // ),
+                // ],
+                // 기존 로비화면
+                )));
     ;
   }
 }

--- a/lib/screens/LoginScreen.dart
+++ b/lib/screens/LoginScreen.dart
@@ -36,11 +36,10 @@ class _LoginScreenState extends State<LoginScreen> {
 
     /// 저장되어있는 유저정보가 있다면 인트로페이지로 갑니다
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      String? userInfo = await _storage.read(key: "UserSignInData");
-      print(userInfo);
+      String? phoneNum = await _storage.read(key: "phoneNum");
 
-      if (userInfo != null) {
-        globals.MY_PHONE_NUM = userInfo;
+      if (phoneNum != null) {
+        globals.MY_PHONE_NUM = phoneNum;
         // ignore: use_build_context_synchronously
         Navigator.push(
           context,
@@ -88,7 +87,7 @@ class _LoginScreenState extends State<LoginScreen> {
         });
       }
 
-      addUserSignInData(
+      addphoneNum(
         name: nameTextController.text,
         phoneNum: phoneNumberTextController.text,
       );
@@ -107,11 +106,12 @@ class _LoginScreenState extends State<LoginScreen> {
     }
   }
 
-  Future<void> addUserSignInData({
+  Future<void> addphoneNum({
     required name,
     required phoneNum,
   }) async {
-    await _storage.write(key: "UserSignInData", value: phoneNum);
+    await _storage.write(key: "phoneNum", value: phoneNum);
+    globals.MY_PHONE_NUM = phoneNum;
     print("로그인 정보 저장 완료");
   }
 

--- a/lib/screens/LoginScreen.dart
+++ b/lib/screens/LoginScreen.dart
@@ -11,6 +11,7 @@ import 'package:telepathy_flutter/screens/Intro/Intro.dart';
 import '../functions/fcmController/fcmController.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:go_router/go_router.dart';
+import 'package:telepathy_flutter/global.dart' as globals;
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -39,6 +40,7 @@ class _LoginScreenState extends State<LoginScreen> {
       print(userInfo);
 
       if (userInfo != null) {
+        globals.MY_PHONE_NUM = userInfo;
         // ignore: use_build_context_synchronously
         Navigator.push(
           context,
@@ -109,8 +111,7 @@ class _LoginScreenState extends State<LoginScreen> {
     required name,
     required phoneNum,
   }) async {
-    final encodedValue = jsonEncode({"$name": "$phoneNum"});
-    await _storage.write(key: "UserSignInData", value: encodedValue);
+    await _storage.write(key: "UserSignInData", value: phoneNum);
     print("로그인 정보 저장 완료");
   }
 

--- a/lib/screens/LoginScreen.dart
+++ b/lib/screens/LoginScreen.dart
@@ -27,41 +27,29 @@ class _LoginScreenState extends State<LoginScreen> {
   late TextEditingController nameTextController;
   late TextEditingController phoneNumberTextController;
 
-  // getData() async {
-  //   var result = await firestore.collection('example').doc("exampleDocs").get();
-  //   print(result);
-  //   return result;
-  // }
-
   @override
   void initState() {
     super.initState();
     nameTextController = TextEditingController();
     phoneNumberTextController = TextEditingController();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      getTempSavedSignIn();
+    /// 저장되어있는 유저정보가 있다면 인트로페이지로 갑니다
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      String? userInfo = await _storage.read(key: "UserSignInData");
+      print(userInfo);
+
+      if (userInfo != null) {
+        // ignore: use_build_context_synchronously
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (context) => const IntroScreen()),
+        );
+      }
     });
   }
 
-  getTempSavedSignIn() async {
-    //read 함수를 통하여 key값에 맞는 정보를 불러오게 됩니다. 이때 불러오는 결과의 타입은 String 타입임을 기억해야 합니다.
-    //(데이터가 없을때는 null을 반환을 합니다.)
-    String? userInfo = await _storage.read(key: "TempSavedSignIn");
-    print(userInfo);
-
-    //user의 정보가 있다면 바로 로그아웃 페이지로 넝어가게 합니다.
-    if (userInfo != null) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(builder: (context) => const IntroScreen()),
-      );
-    }
-  }
-
-  //같은 doc으로 보내면, 초기화가 됨
+  /// 입력 정보가 올바른지 불린을 응답합니다.
   bool isValidInput() {
-    // TODO: 벨리데이션 함수로 분리 필요
     if (phoneNumberTextController.text.length != 11 ||
         phoneNumberTextController.text.substring(0, 3) != "010") {
       print(phoneNumberTextController.text);
@@ -69,12 +57,12 @@ class _LoginScreenState extends State<LoginScreen> {
       return false;
     }
     // if (phoneNumberTextController.text)
-    if (nameTextController.text.length == 0) {
+    if (nameTextController.text.isEmpty) {
       print(nameTextController.text);
       print("이름이 비어있습니다");
       return false;
     }
-    print("이름, 번호 유효성 확인!");
+    print("이름, 번호 유효성 확인완료!");
     return true;
   }
 
@@ -98,7 +86,7 @@ class _LoginScreenState extends State<LoginScreen> {
         });
       }
 
-      addTempSavedSignIn(
+      addUserSignInData(
         name: nameTextController.text,
         phoneNum: phoneNumberTextController.text,
       );
@@ -117,15 +105,13 @@ class _LoginScreenState extends State<LoginScreen> {
     }
   }
 
-  Future<void> addTempSavedSignIn({
+  Future<void> addUserSignInData({
     required name,
     required phoneNum,
   }) async {
     final encodedValue = jsonEncode({"$name": "$phoneNum"});
-    await _storage.write(key: "TempSavedSignIn", value: encodedValue);
+    await _storage.write(key: "UserSignInData", value: encodedValue);
     print("로그인 정보 저장 완료");
-    String? tempSavedText = await _storage.read(key: "TempSavedSignIn");
-    print("$tempSavedText");
   }
 
   @override
@@ -212,6 +198,7 @@ class _LoginScreenState extends State<LoginScreen> {
                           onPressed: () async {
                             if (isValidInput()) {
                               await SignIn();
+                              // ignore: use_build_context_synchronously
                               Navigator.push(
                                 context,
                                 MaterialPageRoute(
@@ -230,6 +217,7 @@ class _LoginScreenState extends State<LoginScreen> {
                   ),
                 ]
                 // 새 로비화면 end
+                //
                 // 기존 로비화면
                 // children: [
                 //   Column(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -484,7 +484,7 @@ packages:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.1"
   shared_preferences:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _flutterfire_internals
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.9"
+    version: "1.0.8"
   args:
     dependency: transitive
     description:
@@ -56,21 +56,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.0.5"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.9.0"
+    version: "5.8.5"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.0.5"
   collection:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.2.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -484,7 +484,7 @@ packages:
       name: riverpod
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   shared_preferences:
     dependency: transitive
     description:


### PR DESCRIPTION
카카오톡 로그인을 본격 도입하기 전에 임시 회원가입 및 자동 로그인 기능을 구현하였습니다.
임시이기 때문에 패스워드는 없으며 이름과 전화번호를 입력하면 로그인 할 수 있습니다.
로그인 시 전화번호는 secure_storage 에 저장되어 자동로그인에 사용됩니다.


추가.
기존 상수로 사용되면 전화번호를 로그인 유저의 전화번호로 대체합니다. 
이제 로그인 유저의 번호로 텔레파시를 보낼 수 있습니다.